### PR TITLE
Add optional install step to pak builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,15 @@ script to create `dist/hello-world.pak`:
 ./tools/make-dist.sh
 ```
 
-Copy the resulting file to `roms/paks/` on the TrimUI Brick SD card to test it.
+If you have the SD card mounted on your computer you can pass the destination
+path (usually `roms/paks/`) and the script will copy the pak for you:
+
+```bash
+./tools/make-dist.sh /media/trimui/roms/paks
+```
+
+Otherwise copy `dist/hello-world.pak` to `roms/paks/` on the TrimUI Brick SD
+card to test it.
 
 ## Installation
 

--- a/tools/make-dist.sh
+++ b/tools/make-dist.sh
@@ -6,9 +6,39 @@ DIST_DIR="${ROOT_DIR}/dist"
 PAK_NAME="hello-world"
 OUTPUT="${DIST_DIR}/${PAK_NAME}.pak"
 
+usage() {
+  cat <<EOF
+Usage: ${0##*/} [TARGET_DIRECTORY]
+
+Builds ${PAK_NAME}.pak into the dist/ folder. If TARGET_DIRECTORY is
+provided the freshly built pak will also be copied into that directory.
+This is handy when the TrimUI SD card is mounted on your computer, e.g.:
+
+    ${0##*/} /media/trimui/roms/paks
+
+EOF
+}
+
+if [[ $# -gt 1 ]]; then
+  usage >&2
+  exit 1
+fi
+
+TARGET_DIR="${1:-}"
+
 rm -f "${OUTPUT}"
 mkdir -p "${DIST_DIR}"
 
 ( cd "${ROOT_DIR}/${PAK_NAME}" && zip -r "${OUTPUT}" . >/dev/null )
 
 printf 'Created %s\n' "${OUTPUT}"
+
+if [[ -n "${TARGET_DIR}" ]]; then
+  if [[ ! -d "${TARGET_DIR}" ]]; then
+    printf 'Error: target "%s" is not a directory.\n' "${TARGET_DIR}" >&2
+    exit 1
+  fi
+  install_path="${TARGET_DIR%/}/${PAK_NAME}.pak"
+  cp "${OUTPUT}" "${install_path}"
+  printf 'Copied to %s\n' "${install_path}"
+fi


### PR DESCRIPTION
## Summary
- enhance tools/make-dist.sh to optionally copy the built pak to a mounted SD card directory
- document the new optional destination parameter in the README so the pak can be dragged straight to the card

## Testing
- ./tools/make-dist.sh
- ./tools/make-dist.sh /tmp/paks

------
https://chatgpt.com/codex/tasks/task_e_68d439b30f8c832aac9126cf841141a7